### PR TITLE
Extract publishing identifiers for FlowMods into a separate API function

### DIFF
--- a/include/dobby_oflib.hrl
+++ b/include/dobby_oflib.hrl
@@ -4,13 +4,11 @@
 %%%=============================================================================
 %% Add includes and records
 
--type flow_path() :: [#{DatapathId :: binary() =>
-                                      list({OFVersion :: 4 | 5, [flow_mod()]})
-                       }].
-
 -type of_version() :: 4 | 5.
 
 -type flow_mod() :: {Matches :: [term()],
                      Instructions :: [term()],
                      Opts :: [term()]}.
+
+-type datapath_flow_mod() :: {dby_identifier(), of_version(), flow_mod()}.
 

--- a/src/dofl_identifier.erl
+++ b/src/dofl_identifier.erl
@@ -21,12 +21,14 @@
 %%% External functions
 %%%=============================================================================
 
--spec net_flow(dby_identifier(), dby_identifier()) -> dby_endpoint().
+-spec net_flow(dby_identifier(), dby_identifier()) ->
+                      {dby_identifier(), [tuple()]}.
 
 net_flow(Src, Dst) ->
     {<<"NF:", Src/binary, ":", Dst/binary>>, [{type, of_net_flow}]}.
 
--spec flow_mod(dby_identifier(), of_version(), flow_mod()) -> dby_endpoint().
+-spec flow_mod(dby_identifier(), of_version(), flow_mod()) ->
+                      {dby_identifier(), [tuple()]}.
 
 flow_mod(Dpid, OFVersion, FlowMod) ->
     {_Matches, _Instructions, Opts} = FlowMod,
@@ -34,7 +36,8 @@ flow_mod(Dpid, OFVersion, FlowMod) ->
     {Cookie, [{type, of_flow_mod}, {dpid, Dpid}, {of_version, OFVersion}]}.
 
 
--spec flow_table(dby_identifier(), flow_mod()) -> dby_identifier().
+-spec flow_table(dby_identifier(), flow_mod()) ->
+                        dby_identifier() | {error, Reason :: term()}.
 
 flow_table(DatapahtId, {_Matches, _Actions, Opts}) ->
     TableNo = proplists:get_value(table_id, Opts),

--- a/src/dofl_link_metadata.erl
+++ b/src/dofl_link_metadata.erl
@@ -21,13 +21,13 @@
 %%% External functions
 %%%=============================================================================
 
--spec endpoint_with_net_flow(dby_identifier()) -> map().
+-spec endpoint_with_net_flow(dby_identifier()) -> [tuple()].
 
 endpoint_with_net_flow(Src) ->
     [{type, ep_to_nf}, {src, Src}].
 
 
--spec net_flow_with_flow_mod(dby_identifier(), dby_identifier()) -> map().
+-spec net_flow_with_flow_mod(dby_identifier(), dby_identifier()) -> [tuple()].
 
 net_flow_with_flow_mod(Src, NetFlowId) when Src =:= NetFlowId ->
     of_path_link_metadata(of_path_starts_at, Src, [NetFlowId]);
@@ -35,13 +35,13 @@ net_flow_with_flow_mod(Src, NetFlowId) ->
     of_path_link_metadata(of_path_ends_at, Src, [NetFlowId]).
 
 
--spec between_flow_mods(dby_identifier(), dby_identifier()) -> map().
+-spec between_flow_mods(dby_identifier(), dby_identifier()) -> [tuple()].
 
 between_flow_mods(Src, NetFlowId) ->
     of_path_link_metadata(of_path_forwards_to, Src, [NetFlowId]).
 
 
--spec flow_mod_with_flow_table() -> map().
+-spec flow_mod_with_flow_table() -> [tuple()].
 
 flow_mod_with_flow_table() ->
     [{type, of_resource}].

--- a/test/dofl_test_utils.erl
+++ b/test/dofl_test_utils.erl
@@ -12,6 +12,7 @@
          flow_path/0,
          flow_path_to_identifiers/1,
          flow_mod/0,
+         flow_mod/1,
          flow_mod_to_table_no/1]).
 
 -include_lib("eunit/include/eunit.hrl").
@@ -69,6 +70,14 @@ flow_mod() ->
      [{table_id, 0}, {priority, 100},
       {idle_timeout, 0}, {idle_timeout, 0},
       {cookie, <<0,0,0,0,0,0,0,102>>},
+      {cookie_mask, <<0,0,0,0,0,0,0,0>>}]}.
+
+flow_mod(Cookie) ->
+    {[{in_port,2}],
+     [{apply_actions,[{output,1,no_buffer}]}],
+     [{table_id, 0}, {priority, 100},
+      {idle_timeout, 0}, {idle_timeout, 0},
+      {cookie, Cookie},
       {cookie_mask, <<0,0,0,0,0,0,0,0>>}]}.
 
 flow_mod_to_table_no({_Matches, _Actions, Opts}) ->

--- a/test/dofl_with_server_SUITE.erl
+++ b/test/dofl_with_server_SUITE.erl
@@ -49,10 +49,10 @@ end_per_testcase(_, Config) ->
     Config.
 
 all() ->
-    [should_return_path_with_flow_mods].
-    %% [should_publish_net_flow,
-    %%  should_find_flow_table_identifers,
-%%  should_publish_flow_path].
+    [should_return_path_with_flow_mods,
+     should_publish_net_flow,
+     should_find_flow_table_identifers,
+     should_publish_flow_path].
 
 daisychain_identifiers() ->
     [{endpoints, {<<"EP1">>, <<"EP2">>}},


### PR DESCRIPTION
It introduces new function: dobby_oflib:publish_dp_flow_mod/2.
