### PR TITLE
Fix test failure

### DIFF
--- a/test/dofl_with_server_SUITE.erl
+++ b/test/dofl_with_server_SUITE.erl
@@ -139,6 +139,8 @@ assert_flow_path(NetFlowId, FlowModsIds) ->
 
 setup_dobby(Config) ->
     application:stop(dobby),
+    application:load(erl_mnesia),
+    application:set_env(erl_mnesia, options, [persistent]),
     {ok, _} = application:ensure_all_started(dobby),
     ok = dby_bulk:import(json0, ?config(add_topo_filename, Config)).
 


### PR DESCRIPTION
Configure erl_mnesia to use persistent storage, since Dobby depends on this being set.